### PR TITLE
Update Github Pages path

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/jekyll-build-pages@v1
         with:
           source: ./rss/
-          destination: ./_site/rss/
+          destination: ./_site/
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -15,7 +15,7 @@
 
 - 为 RSS 订阅源添加基于标题，内容，URL 的关键词过滤器。
 
-# 更新日志
+## 更新日志
 
 查看 [CHANGELOG.md](CHANGELOG-zh.md) 查看最新更新。
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -33,7 +33,7 @@
 
     - OPENAI_API_KEY: 你的 OpenAI API 密钥,在[这里](https://platform.openai.com/account/api-keys)获取
 
-- 在仓库设置中启用 GitHub Actions 部署 GitHub Pages
+- 在仓库设置中启用 GitHub Pages，选择**从 `auto-commit` 分支** 部署
 
 - 在 `config.ini` 中配置你的RSS订阅源
 
@@ -43,9 +43,9 @@
 
 ## 分享几条本项目处理后的 RSS 订阅源
 
-我自己用此脚本总结的一些 RSS订阅源托管在本项目[auto-commit分支](https://github.com/yinan-c/RSS-GPT/tree/auto-commit)的 `rss/` 目录下，这样做的目的是把对脚本的手动更新和 GitHub Workflow 自动提交的内容分开。你可以查看[CHANGELOG.md](CHANGELOG.md)查看更多细节。
+我自己用此脚本总结的一些 RSS订阅源托管在本项目[auto-commit分支](https://github.com/yinan-c/RSS-GPT/tree/auto-commit)的 `rss/` 目录下，这样做的目的是把对脚本的手动更新和 GitHub Workflow 自动提交的内容分开。你可以查看[CHANGELOG.md](CHANGELOG.md)中 2023-09-19 的更新了解更多细节。
 
-这些订阅源也可以在我的 [GitHub Pages](https://yinan.me/RSS-GPT/rss/)上找到。欢迎在你的 RSS 阅读器中订阅。
+这些订阅源也可以在我的 [GitHub Pages](https://yinan.me/RSS-GPT/)上找到。欢迎在你的 RSS 阅读器中订阅。
 
 如果有任何问题或有关于 rss feeds 的建议，欢迎邮件联系我。
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Check out the [CHANGELOG.md](CHANGELOG.md) for the latest changes.
     - U_EMAIL: your GitHub email
     - WORK_TOKEN: your GitHub personal access with `repo` and `workflow` scope
     - OPENAI_API_KEY: your OpenAI API key, get it from [here](https://platform.openai.com/account/api-keys)
-- Enable GitHub Actions to deploy GitHub Pages in repo settings
+- Enable GitHub Pages **deployment from the `auto-commit` branch** in the repo settings
 - Configure your RSS feeds in config.ini
 - Change the links in 'main.py' to your own GitHub pages.
 
@@ -33,8 +33,8 @@ You can check out [here](https://yinan.me/rss-gpt-manual-en.html) for a more det
 
 ## Example feeds being processed
 
-These feeds on hosted in the rss/ directory of the [auto-commit branch](https://github.com/yinan-c/RSS-GPT/tree/auto-commit) of this repo in order to separate the manually committed content from the automatically committed content. You can check out the [CHANGELOG.md](CHANGELOG.md) for more details on this change.
+These feeds on hosted in the `rss/` directory of the [auto-commit branch](https://github.com/yinan-c/RSS-GPT/tree/auto-commit) of this repo in order to separate the manually committed content from the automatically committed content. You can check out the [CHANGELOG.md](CHANGELOG.md) for more details about the update on 2021-09-19.
 
-The feeds are also on my [GitHub Pages](https://yinan.me/RSS-GPT/rss/). Feel free to subscribe in your favorite RSS reader.
+The feeds are also on my [GitHub Pages](https://yinan.me/RSS-GPT/). Feel free to subscribe in your favorite RSS reader.
 
 I will consider hosting more feeds in the future. Email me or submit an issue if there is any question using the script or any suggestions.

--- a/main.py
+++ b/main.py
@@ -306,7 +306,7 @@ for x in secs[1:]:
     output(x, language=language)
     feed = {"url": get_cfg(x, 'url').replace(',','<br>'), "name": get_cfg(x, 'name')}
     feeds.append(feed)  # for rendering index.html
-    links.append("- "+ get_cfg(x, 'url').replace(',',', ') + " -> https://yinan-c.github.io/RSS-GPT/rss/" + feed['name'] + ".xml\n")
+    links.append("- "+ get_cfg(x, 'url').replace(',',', ') + " -> https://yinan-c.github.io/RSS-GPT/" + feed['name'] + ".xml\n")
     if readme_lines[-1].startswith("- "):
         readme_lines = readme_lines[:-1]  # remove 1 line from the end for each feed
 


### PR DESCRIPTION
- Now the feeds are in `{github page path}/RSS-GPT/` instead of `{github page path}/RSS-GPT/rss`
- Settings changes needed because of new branch created, updated the instruction in readme