### PR TITLE
update github pages url path, added rss/ back

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -45,7 +45,7 @@
 
 我自己用此脚本总结的一些 RSS订阅源托管在本项目[auto-commit分支](https://github.com/yinan-c/RSS-GPT/tree/auto-commit)的 `rss/` 目录下，这样做的目的是把对脚本的手动更新和 GitHub Workflow 自动提交的内容分开。你可以查看[CHANGELOG.md](CHANGELOG.md)中 2023-09-19 的更新了解更多细节。
 
-这些订阅源也可以在我的 [GitHub Pages](https://yinan.me/RSS-GPT/)上找到。欢迎在你的 RSS 阅读器中订阅。
+这些订阅源也可以在我的 [GitHub Pages](https://yinan.me/RSS-GPT/rss/)上找到。欢迎在你的 RSS 阅读器中订阅。
 
 如果有任何问题或有关于 rss feeds 的建议，欢迎邮件联系我。
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ You can check out [here](https://yinan.me/rss-gpt-manual-en.html) for a more det
 
 These feeds on hosted in the `rss/` directory of the [auto-commit branch](https://github.com/yinan-c/RSS-GPT/tree/auto-commit) of this repo in order to separate the manually committed content from the automatically committed content. You can check out the [CHANGELOG.md](CHANGELOG.md) for more details about the update on 2021-09-19.
 
-The feeds are also on my [GitHub Pages](https://yinan.me/RSS-GPT/). Feel free to subscribe in your favorite RSS reader.
+The feeds are also on my [GitHub Pages](https://yinan.me/RSS-GPT/rss/). Feel free to subscribe in your favorite RSS reader.
 
 I will consider hosting more feeds in the future. Email me or submit an issue if there is any question using the script or any suggestions.

--- a/main.py
+++ b/main.py
@@ -306,7 +306,7 @@ for x in secs[1:]:
     output(x, language=language)
     feed = {"url": get_cfg(x, 'url').replace(',','<br>'), "name": get_cfg(x, 'name')}
     feeds.append(feed)  # for rendering index.html
-    links.append("- "+ get_cfg(x, 'url').replace(',',', ') + " -> https://yinan-c.github.io/RSS-GPT/" + feed['name'] + ".xml\n")
+    links.append("- "+ get_cfg(x, 'url').replace(',',', ') + " -> https://yinan-c.github.io/RSS-GPT/rss/" + feed['name'] + ".xml\n")
     if readme_lines[-1].startswith("- "):
         readme_lines = readme_lines[:-1]  # remove 1 line from the end for each feed
 


### PR DESCRIPTION
It seems the deployment now is for the whole repo,  and the feeds are still inside the `rss/` directory, so I added `rss/` back in the url path.